### PR TITLE
remove homeishome as outdated

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,7 +5,7 @@ license: GPL-3.0+
 
 base: core22
 confinement: strict
-      
+
 apps:
   savedesktop:
     extensions: [gnome]
@@ -15,10 +15,6 @@ apps:
     plugs:
       - home
       - network
-    environment: 
-      HOME: $SNAP_REAL_HOME
-    command-chain:
-      - bin/homeishome-launch
 
 parts:
   dconf:
@@ -61,10 +57,7 @@ parts:
       cp -R $CRAFT_PART_SRC/translations $CRAFT_PART_INSTALL/usr/
       install -Dm755 -t $CRAFT_PART_INSTALL/usr/bin $CRAFT_PART_SRC/run.sh
     parse-info: [ usr/share/metainfo/io.github.vikdevelop.SaveDesktop.metainfo.xml ]
-  homeishome-launch:
-    plugin: nil
-    stage-snaps:
-      - homeishome-launch
+
   deps:
     plugin: nil
     stage-packages:


### PR DESCRIPTION
The homeishome is outdated and I have kept the real home for snaps properly in my previous PR, as you can see here

https://github.com/vikdevelop/SaveDesktop/blob/main/src/localization.py#L43

and there is no need to change the `HOME` also. 