### PR TITLE
Add ability to save immediately from the CLI

### DIFF
--- a/native/run_natively.sh
+++ b/native/run_natively.sh
@@ -7,6 +7,9 @@ then
 elif [ "$1" == "--background" ]
 	then
 		python3 src/periodic_saving.py
+elif [ "$1" == "--save-now" ]
+	then
+		python3 src/periodic_saving.py --now
 elif [ "$1" == "--sync" ]
 	then
 		python3 src/network_sharing.py
@@ -25,7 +28,7 @@ elif [ "$1" == "--import-config" ]
 		python3 ~/.local/share/savedesktop/src/config.py --import_
 elif [ "$1" == "--help" ]
 	then
-   		echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --help | Show this message'
+   		echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --save-now | Save configuration of DE using parameters from UI\n  --help | Show this message'
 fi
 
 cd

--- a/native/run_natively.sh
+++ b/native/run_natively.sh
@@ -1,34 +1,26 @@
 #!/usr/bin/bash
 CACHE=${HOME}/.cache/io.github.vikdevelop.SaveDesktop
 cd ~/.local/share/savedesktop
-if [ "$1" == "" ]
-then 
-	python3 src/main_window.py
-elif [ "$1" == "--background" ]
-	then
-		python3 src/periodic_saving.py
-elif [ "$1" == "--save-now" ]
-	then
-		python3 src/periodic_saving.py --now
-elif [ "$1" == "--sync" ]
-	then
-		python3 src/network_sharing.py
-elif [ "$1" == "--start-server" ]
-	then
-		python3 src/server.py
-elif [ "$1" == "--update" ]
-	then
-		python3 ~/.local/bin/native_updater.py
-elif [ "$1" == "--import-config" ]
-	then
-		echo -e '{\n "import_file": "'$2'"\n}'> $CACHE/.impfile.json
-		mkdir $CACHE/import_config
-		rm -rf $CACHE/import_config/*
-		cd $CACHE/import_config
-		python3 ~/.local/share/savedesktop/src/config.py --import_
-elif [ "$1" == "--help" ]
-	then
-   		echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --save-now | Save configuration of DE using parameters from UI\n  --help | Show this message'
+if [ "$1" == "" ]; then
+    python3 src/main_window.py
+elif [ "$1" == "--background" ]; then
+    python3 src/periodic_saving.py
+elif [ "$1" == "--save-now" ]; then
+    python3 src/periodic_saving.py --now
+elif [ "$1" == "--sync" ]; then
+    python3 src/network_sharing.py
+elif [ "$1" == "--start-server" ]; then
+    python3 src/server.py
+elif [ "$1" == "--update" ]; then
+    python3 ~/.local/bin/native_updater.py
+elif [ "$1" == "--import-config" ]; then
+    echo -e '{\n "import_file": "'$2'"\n}'> $CACHE/.impfile.json
+    mkdir $CACHE/import_config
+    rm -rf $CACHE/import_config/*
+    cd $CACHE/import_config
+    python3 ~/.local/share/savedesktop/src/config.py --import_
+elif [ "$1" == "--help" ]; then
+    echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --save-now | Save configuration of DE using parameters from UI\n --help | Show this message'
 fi
 
 cd

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,9 @@ then
 elif [ "$1" == "--background" ]
 	then
 		python3 /app/periodic_saving.py
+elif [ "$1" == "--save-now" ]
+	then
+		python3 /app/periodic_saving.py --now
 elif [ "$1" == "--sync" ]
 	then
 		python3 /app/network_sharing.py
@@ -26,7 +29,7 @@ elif [ "$1" == "--import-config" ]
 		python3 /app/config.py --import_
 elif [ "$1" == "--help" ]
 	then
-   		echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --help | Show this message'
+   		echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --save-now | Save configuration of DE using parameters from UI\n  --help | Show this message'
 fi
 else
   if [ "$1" == "" ]
@@ -35,6 +38,9 @@ else
 	elif [ "$1" == "--background" ]
   then
 			python3 $SNAP/usr/periodic_saving.py
+	elif [ "$1" == "--save-now" ]
+  then
+			python3 $SNAP/usr/periodic_saving.py --now
 	elif [ "$1" == "--sync" ]
 		then
 			python3 $SNAP/usr/network_sharing.py
@@ -50,6 +56,6 @@ else
 		python3 $SNAP/usr/config.py --import_
 	elif [ "$1" == "--help" ]
 	then
-   		echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --help | Show this message'
+   		echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --save-now | Save configuration of DE using parameters from UI\n  --help | Show this message'
   fi
 fi 

--- a/run.sh
+++ b/run.sh
@@ -3,59 +3,44 @@
 CACHE=${HOME}/.var/app/io.github.vikdevelop.SaveDesktop/cache/tmp/
 CACHE_SNAP=$SNAP_USER_COMMON/.cache/tmp
 
-if [ "$SNAP" == "" ]
-then 
-	if [ "$1" == "" ]
-  then
-	  python3 /app/main_window.py
-elif [ "$1" == "--background" ]
-	then
-		python3 /app/periodic_saving.py
-elif [ "$1" == "--save-now" ]
-	then
-		python3 /app/periodic_saving.py --now
-elif [ "$1" == "--sync" ]
-	then
-		python3 /app/network_sharing.py
-elif [ "$1" == "--start-server" ]
-	then
-		python3 /app/server.py
-elif [ "$1" == "--import-config" ]
-	then
-		echo -e '{\n "import_file": "'$2'"\n}'> $CACHE/.impfile.json
-		mkdir $CACHE/import_config
-		rm -rf $CACHE/import_config/*
-		cd $CACHE/import_config
-		python3 /app/config.py --import_
-elif [ "$1" == "--help" ]
-	then
-   		echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --save-now | Save configuration of DE using parameters from UI\n  --help | Show this message'
-fi
+if [ "$SNAP" == "" ]; then
+    if [ "$1" == "" ]; then
+        python3 /app/main_window.py
+    elif [ "$1" == "--background" ]; then
+        python3 /app/periodic_saving.py
+    elif [ "$1" == "--save-now" ]; then
+        python3 /app/periodic_saving.py --now
+    elif [ "$1" == "--sync" ]; then
+        python3 /app/network_sharing.py
+    elif [ "$1" == "--start-server" ]; then
+        python3 /app/server.py
+    elif [ "$1" == "--import-config" ]; then
+        echo -e '{\n "import_file": "'$2'"\n}'> $CACHE/.impfile.json
+        mkdir $CACHE/import_config
+        rm -rf $CACHE/import_config/*
+        cd $CACHE/import_config
+        python3 /app/config.py --import_
+    elif [ "$1" == "--help" ]; then
+        echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --save-now | Save configuration of DE using parameters from UI\n --help | Show this message'
+    fi
 else
-  if [ "$1" == "" ]
-  then 
-		python3 $SNAP/usr/main_window.py
-	elif [ "$1" == "--background" ]
-  then
-			python3 $SNAP/usr/periodic_saving.py
-	elif [ "$1" == "--save-now" ]
-  then
-			python3 $SNAP/usr/periodic_saving.py --now
-	elif [ "$1" == "--sync" ]
-		then
-			python3 $SNAP/usr/network_sharing.py
-	elif [ "$1" == "--start-server" ]
-		then
-			python3 $SNAP/usr/server.py
-	elif [ "$1" == "--import-config" ]
-	then
-		echo -e '{\n "import_file": "'$2'"\n}'> $CACHE/.impfile.json
-		mkdir $CACHE_SNAP/import_config
-		rm -rf $CACHE_SNAP/import_config/*
-		cd $CACHE_SNAP/import_config
-		python3 $SNAP/usr/config.py --import_
-	elif [ "$1" == "--help" ]
-	then
-   		echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --save-now | Save configuration of DE using parameters from UI\n  --help | Show this message'
-  fi
-fi 
+    if [ "$1" == "" ]; then
+        python3 $SNAP/usr/main_window.py
+    elif [ "$1" == "--background" ]; then
+        python3 $SNAP/usr/periodic_saving.py
+    elif [ "$1" == "--save-now" ]; then
+        python3 $SNAP/usr/periodic_saving.py --now
+    elif [ "$1" == "--sync" ]; then
+        python3 $SNAP/usr/network_sharing.py
+    elif [ "$1" == "--start-server" ]; then
+        python3 $SNAP/usr/server.py
+    elif [ "$1" == "--import-config" ]; then
+        echo -e '{\n "import_file": "'$2'"\n}'> $CACHE/.impfile.json
+        mkdir $CACHE_SNAP/import_config
+        rm -rf $CACHE_SNAP/import_config/*
+        cd $CACHE_SNAP/import_config
+        python3 $SNAP/usr/config.py --import_
+    elif [ "$1" == "--help" ]; then
+        echo -e '\033[1mArguments:\033[0m \n None | Run SaveDesktop app (GUI) \n --background | Start periodic saving \n --sync | Sync desktop configuration with other computer \n --start-server | Start HTTP server for synchronization DE config with other computers \n --import-config /path/to/filename.sd.tar.gz | Import configuration of DE \n --save-now | Save configuration of DE using parameters from UI\n --help | Show this message'
+    fi
+fi

--- a/src/periodic_saving.py
+++ b/src/periodic_saving.py
@@ -20,7 +20,7 @@ download_dir = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD)
 class PeriodicBackups:
     def __init__(self):
         self.settings = Gio.Settings.new_with_path("io.github.vikdevelop.SaveDesktop", "/io/github/vikdevelop/SaveDesktop/")
-        
+
     def run(self, now: bool) -> None:
         # Get directory for storing periodic backups
         if self.settings["periodic-saving-folder"] == '':
@@ -41,7 +41,7 @@ class PeriodicBackups:
                 self.get_interval()
         else:
             self.get_interval()
-        
+
     def get_interval(self):
         # Get periodic saving interval selected by the user
         if self.settings["periodic-saving"] == 'Never':
@@ -53,25 +53,25 @@ class PeriodicBackups:
             self.weekly()
         elif self.settings["periodic-saving"] == 'Monthly':
             self.monthly()
-         
+
     # Periodic backups: daily
     def daily(self):
         self.backup()
-        
+
     # Periodic backups: weekly
     def weekly(self):
         if date.today().weekday() == 0:
             self.backup()
         else:
             print("Today is not Monday.")
-            
+
     # Periodic backups: monthly
     def monthly(self):
         if dt.day == 1:
             self.backup()
         else:
             print("Today is not first day of month.")
-    
+
     # Create backup
     def backup(self):
         if self.pbfolder == f'{download_dir}/SaveDesktop/archives':
@@ -95,7 +95,7 @@ class PeriodicBackups:
         os.system(f"python3 {system_dir}/config.py --save")
         os.system(f"rm {CACHE}/.periodicfile.json")
         self.config_saved()
-      
+
     # Message about saved config
     def config_saved(self):
         os.system(f"rm -rf {CACHE}/periodic-saving/*")
@@ -103,7 +103,7 @@ class PeriodicBackups:
             pb.write('{\n "saving-date": "%s"\n}' % date.today())
         print("Configuration saved.")
         exit()
-    
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--now", help="Save now", action="store_true")

--- a/src/periodic_saving.py
+++ b/src/periodic_saving.py
@@ -1,3 +1,4 @@
+import argparse
 from datetime import datetime
 from datetime import date
 from pathlib import Path
@@ -20,13 +21,17 @@ class PeriodicBackups:
     def __init__(self):
         self.settings = Gio.Settings.new_with_path("io.github.vikdevelop.SaveDesktop", "/io/github/vikdevelop/SaveDesktop/")
         
+    def run(self, now: bool) -> None:
         # Get directory for storing periodic backups
         if self.settings["periodic-saving-folder"] == '':
             self.pbfolder = f'{download_dir}/SaveDesktop/archives'
         else:
             self.pbfolder = f'{self.settings["periodic-saving-folder"]}'
-            
-        if os.path.exists(f"{DATA}/periodic-saving.json"):
+
+        if now:
+            print("Saving immediately")
+            self.backup()
+        elif os.path.exists(f"{DATA}/periodic-saving.json"):
             with open(f"{DATA}/periodic-saving.json") as pb:
                 jp = json.load(pb)
             if jp["saving-date"] == f'{date.today()}':
@@ -99,4 +104,10 @@ class PeriodicBackups:
         print("Configuration saved.")
         exit()
     
-PeriodicBackups()
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--now", help="Save now", action="store_true")
+    args = parser.parse_args()
+
+    pb = PeriodicBackups()
+    pb.run(args.now)


### PR DESCRIPTION
Provides mechanism to bypass scheduling and simply save from the CLI.

Also did a quick pass resolving mix of tab and spaces in the shell scripts, removed trailing spaces in the modified Python file. These changes can be removed if you don't want them. (Ideally though you wouldn't have the 3x duplication between the wrapper shell scripts.)

The `run_natively.sh` changes haven't been tested.

Closes #272