### PR TITLE
Add an autostart delay of 60 seconds to synchronization

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -889,7 +889,7 @@ class MainWindow(Adw.ApplicationWindow):
                 synchronization_content += f'python3 {CACHE}/install_flatpak_from_script.py'
             with open(f"{DATA}/savedesktop-synchronization.sh", "w") as f:
                 f.write(synchronization_content)
-            open(f"{home}/.config/autostart/io.github.vikdevelop.SaveDesktop.sync.desktop", "w").write(f"[Desktop Entry]\nName=SaveDesktop (Synchronization)\nType=Application\nExec=sh {DATA}/savedesktop-synchronization.sh")
+            open(f"{home}/.config/autostart/io.github.vikdevelop.SaveDesktop.sync.desktop", "w").write(f"[Desktop Entry]\nName=SaveDesktop (Synchronization)\nType=Application\nExec=sh {DATA}/savedesktop-synchronization.sh\nX-GNOME-Autostart-Delay=60")
             [os.remove(path) for path in [f"{home}/.config/autostart/io.github.vikdevelop.SaveDesktop.Backup.desktop", f"{home}/.config/autostart/io.github.vikdevelop.SaveDesktop.MountDrive.desktop", f"{home}/.config/autostart/io.github.vikdevelop.SaveDesktop.server.desktop", f"{home}/.config/autostart/io.github.vikdevelop.SaveDesktop.Flatpak.desktop"] if os.path.exists(path)]
     
     # Select folder for periodic backups (Gtk.FileDialog)


### PR DESCRIPTION
## Description
In some cases, online account drives might not be mountable at login and attempting to mount the drive could cause keyring errors. To prevent this condition, this change adds a startup delay of 60 seconds to the autostart desktop entry.

## Related Issue

n/a

## Changes Made

- [x] Fixed bug: Auto start desktop entry now sets a `X-GNOME-Autostart-Delay` value of `60`.
- [x] Updated documentation: Not applicable.

## Screenshots (if applicable)

n/a

## Testing

Select the installation methods on which you tested your changes:

- [x] Flatpak
- [ ] Snap
- [ ] Native version from this repository

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/vikdevelop/SaveDesktop/blob/main/CONTRIBUTING.md).
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation accordingly.
- [x] My changes do not introduce any new warnings.
